### PR TITLE
Update package name to use mist namespace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/${{ github.event.repository.name }}
+      url: https://pypi.org/p/mist.dclean
 
     steps:
       - name: Retrieve release distributions

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="dclean",
+    name="mist.dclean",
     version="0.1.0",
     author="Ivan Statkevich",
     author_email="statkevich.ivan@gmail.com",


### PR DESCRIPTION
- Modify setup.py to change package name from "dclean" to "mist.dclean"
- Prepare for potential namespace packaging